### PR TITLE
gradle build - do not fail the build if publishing credentials are no…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'java'
-apply from: "$rootProject.projectDir/gradle/scripts/publish.gradle"
+
+if( ext.has('ossrhUsername') && ext.has('ossrhPassword')  )
+    apply from: "$rootProject.projectDir/gradle/scripts/publish.gradle"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
…t provided

Hi there,

I was playing around with this project, but the build was failing without publication credentials.

I added a line to only apply the publishing.gradle file when the credentials are available in the project, should you want to accept the pull request.

cheers,
- Dave
